### PR TITLE
Version 1.1.1 update

### DIFF
--- a/format.js
+++ b/format.js
@@ -36,7 +36,6 @@ fill().then(async () => {
     });
     let format = await getFormatOutput();
     document.getElementById("format-output").value = formatAsString(format);
-    pasteToClipboard(format);
 });
 
 
@@ -57,6 +56,11 @@ function showModal(title, messages, type) {
     }
     var modalBox = new bootstrap.Modal(document.getElementById('modalBox'));
     modalBox.show();
+}
+
+document.getElementById(`copyFormatOutputToClipboardBtn`).onclick = async () => {
+    let format = await getFormatOutput();
+    pasteToClipboard(format);
 }
 
 document.getElementById(`applyFormatBtn`).onclick = async () => {

--- a/functionality.js
+++ b/functionality.js
@@ -49,7 +49,7 @@ async function getTransformers() {
             else {
                 resolve({
                     "www.youtube.com": {regex: /^(?:https?:\/\/)?(?:www\.)?youtube\.com\/shorts\/([^\/?]+)$/i, output: "https://www.youtube.com/watch?v=$1"},
-                    "m.youtube.com": {regex: /^(?:https?:\/\/)?(?:m\.)?youtube\.com\/shorts\/([^\/?]+)$/i, output: "https://www.youtube.com/watch?v=$1"}
+                    "m.youtube.com": {regex: /^https?:\/\/(?:m\.)?youtube\.com\/(?:shorts\/)?(?:watch\?v=)?([^\/?]+)$/i, output: "https://www.youtube.com/watch?v=$1"}
                 });
             }
         })

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ShareDis",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "manifest_version": 3,
   "description": "Simple webpage sharing tool",
   "browser_specific_settings": {

--- a/popup.html
+++ b/popup.html
@@ -54,7 +54,7 @@
             <p class="lead">Format Output:</p>
             <input id="format-output" class="form-control" type="text" placeholder="Default output" readonly>
             <p></p>
-
+            <input id="copyFormatOutputToClipboardBtn" class="btn btn-primary" type="button" value="Copy to Clipboard">
             <input id="applyFormatBtn" class="btn btn-primary" type="button" value="Apply">
             <input id="undoFormatBtn" class="btn btn-primary" type="button" value="Undo">
         </div>


### PR DESCRIPTION
This version changes the following:

Clicking the extension on the extensions toolbar (not on the address bar) will no longer copy the format automatically, you still have the option to do it with the Copy to Clipboard output

Improved m.youtube.com default regex