### PR TITLE
Improve default youtube mobile regex

### DIFF
--- a/functionality.js
+++ b/functionality.js
@@ -49,7 +49,7 @@ async function getTransformers() {
             else {
                 resolve({
                     "www.youtube.com": {regex: /^(?:https?:\/\/)?(?:www\.)?youtube\.com\/shorts\/([^\/?]+)$/i, output: "https://www.youtube.com/watch?v=$1"},
-                    "m.youtube.com": {regex: /^https?:\/\/(?:m\.)?youtube\.com\/(?:shorts\/)?(?:watch\?v=)?([^\/?]+)$/i, output: "https://www.youtube.com/watch?v=$1"}
+                    "m.youtube.com": {regex: /^(?:https?:\/\/)?(?:m\.)?youtube\.com\/shorts\/([^\/?]+)(?:\?[^\/]*)?$/i, output: "https://www.youtube.com/watch?v=$1"}
                 });
             }
         })

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ShareDis",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "manifest_version": 3,
   "description": "Simple webpage sharing tool",
   "browser_specific_settings": {


### PR DESCRIPTION
This PR improves the default regex further supporting links generating by the youtube app.

Example:  https://youtube.com/shorts/NELdJLUGVPA?si=BCjOoIDKi1YrULV8  will be transformed accordingly to https://youtube.com/watch?v=NELdJLUGVPA
